### PR TITLE
Include flavor for metadata url

### DIFF
--- a/index.md
+++ b/index.md
@@ -78,15 +78,20 @@ It looks like you are setting up a website for a workshop but you haven't specif
 {% comment %}
 Read correct lesson meta from esciencecenter-digital-skills/workshop-metadata
 {% endcomment %}
-{% capture lesson_meta %}https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/{{info.curriculum}}{% endcapture %}
 
+
+{% if info.flavor %}
+{% capture lesson_meta %}https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/{{info.curriculum}}-{{info.flavor}}{% endcapture %}
+{% else %}
+{% capture lesson_meta %}https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/{{info.curriculum}}{% endcapture %}
+{% endif %}
 
 {% comment %}
 Check DC curriculum
 {% endcomment %}
 
 {% if info.carpentry == "dc" %}
-{% unless info.curriculum == "dc-astronomy" or info.curriculum == "dc-ecology" or info.curriculum == "dc-genomics" or info.curriculum == "dc-socsci" or info.curriculum == "dc-geospatial" %}
+{% unless info.curriculum == "dc-astronomy" or info.curriculum == "dc-ecology" or info.curriculum == "dc-genomics" or info.curriculum == "dc-socsci" %}
 <div class="alert alert-warning">
 It looks like you are setting up a website for a Data Carpentry curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>dc-astronomy</code>, <code>dc-ecology</code>, <code>dc-genomics</code>, <code>dc-socsci</code>, or <code>dc-geospatial</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
 </div>
@@ -109,7 +114,7 @@ Check DS curriculum
 {% endcomment %}
 
 {% if info.carpentry == "ds" %}
-{% unless info.curriculum == "ds-cr" or info.curriculum == "ds-docker" or info.curriculum == "ds-dl-intro" or info.curriculum == "ds-gpu" or info.curriculum == "ds-parallel" or info.curriculum == "ds-rpackaging" %}
+{% unless info.curriculum == "ds-cr" or info.curriculum == "ds-docker" or info.curriculum == "ds-dl-intro" or info.curriculum == "ds-gpu" or info.curriculum == "ds-parallel" or info.curriculum == "ds-rpackaging" or info.curriculum == "ds-geospatial"%}
 <div class="alert alert-warning">
 It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>ds-cr</code>, <code>ds-docker</code>, <code>ds-dl-intro</code>, <code>ds-gpu</code>, <code>ds-parallel</code> or <code>ds-rpackaging</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
 </div>

--- a/index.md
+++ b/index.md
@@ -80,7 +80,7 @@ Read correct lesson meta from esciencecenter-digital-skills/workshop-metadata
 {% endcomment %}
 
 
-{% if info.flavor %}
+{% if info.flavor and info.flavor != 'NA' %}
 {% capture lesson_meta %}https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/{{info.curriculum}}-{{info.flavor}}{% endcapture %}
 {% else %}
 {% capture lesson_meta %}https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/{{info.curriculum}}{% endcapture %}


### PR DESCRIPTION
Fixes #134  
We now include the flavor of the lesson (i.e. R or Python) if it exists. This means lessons of a specific flavour should also be named accordingly in the workshop metadata, i.e. `ds-geospatial-python` or `dc-socsci-python`.

Also regards `ds-geospatial-python` is called `ds-geospatial-python and not `dc-geospatial-python` because it is not part of the official data carpentry curriculum. Therefore it is a digital skills workshop.