### PR TITLE
fix typo

### DIFF
--- a/index.md
+++ b/index.md
@@ -338,7 +338,7 @@ CODE OF CONDUCT
 
 {% if info.carpentry == "ds" %}
 <p>
-Participants are expected to follow those guidelines:
+Participants are expected to follow these guidelines:
 <ul>
   <li>Use welcoming and inclusive language</li>
   <li>Be respectful of different viewpoints and experiences</li>


### PR DESCRIPTION
Yep, that's all. 

I hope that fixing this will mean that this line will show up correctly on the web pages of future workshops? Like, eg., [this one](https://esciencecenter-digital-skills.github.io/2022-12-12-ds-cr/).