### PR TITLE
Increase height eventbrite block

### DIFF
--- a/index.md
+++ b/index.md
@@ -136,7 +136,7 @@ displayed if the 'eventbrite' field in the header is not set.
   src="https://www.eventbrite.com/tickets-external?eid={{eventbrite}}&ref=etckt"
   frameborder="0"
   width="100%"
-  height="280px"
+  height="400px"
   scrolling="auto">
 </iframe>
 {% endif %}


### PR DESCRIPTION
Fix #136 by increasing the eventbrite embed block from 280px to 400px. For a simple registration, this will fit all eventbrite content without generating a scrollbar.


