### PR TITLE
Added icebreaker examples

### DIFF
--- a/files/Icebreakers
+++ b/files/Icebreakers
@@ -1,0 +1,43 @@
+Icebreakers 
+
+The Carpentries Icebreakers [https://carpentries.github.io/instructor-training/icebreakers/]
+
+The Only List of Icebreaker Questions You’ll Ever Need [https://museumhack.com/list-icebreakers-questions/]
+
+- You in 3 words 
+Describe what you do in only three words.
+Notes: We did this with only one word too. It did not work that well. 
+
+- In your own bio-pic, which actor would play YOU?
+Notes: this was a lot of fun in the parallel python workshop 
+
+- What is your favorite Dutch/local/lockdown food? 
+
+- Say something you are proud of (not necessarily related to research). 
+
+- If you could write a book, what would it be about? 
+
+- What is the scariest thing you’ve ever done for fun? 
+
+- What is your spirit animal? 
+
+- Who would win in a fight: a horse-sized duck or 100 duck-sized horses? Why? 
+
+- If you were a color, what would it be?  
+
+- If you were a candy, what would it be today?  
+
+- What superpower would you choose to have? Why? 
+
+- What was your favorite television show as a kid? 
+
+- If you had a time machine, what time period would you travel to? 
+
+- If you could only eat one thing for the rest of your life, what would it be? 
+
+- If you had one wish, what would you wish for? 
+
+- What are your new hobbies due to the pandemic? 
+Notes: Worked quite well. 
+
+- Did you ever try to reproduce a result and failed because the software didn’t work? 


### PR DESCRIPTION
Is this the right place in the workshop-template repository? I thought to have it next to the collaborative document templates because when you make these you start to think about icebreakers and the general introduction?